### PR TITLE
Update download_files in gcs.py to download files locally as intended.

### DIFF
--- a/backend/gen_v/storage/gcs.py
+++ b/backend/gen_v/storage/gcs.py
@@ -72,22 +72,18 @@ def download_file_locally(
   return local_file_path
 
 
-def download_files(
-    gcs_uris: list[str], storage_client: storage.Client = None
-) -> list[str]:
+def download_files(gcs_uris: list[str]) -> list[str]:
   """Downloads files from Google Cloud Storage to the local file system.
 
   Args:
     gcs_uris: A list of Google Cloud Storage URIs of the files to download.
-    storage_client: The Google Cloud Storage client.
 
   Returns:
     A list of local file paths where the files were saved.
   """
-  storage_client = storage_client or storage.Client()
   local_file_paths = []
   for gcs_uri in gcs_uris:
-    local_file_paths.append(download_files(gcs_uri, storage_client))
+    local_file_paths.append(download_file_locally(gcs_uri))
   return local_file_paths
 
 


### PR DESCRIPTION
The `download_files` in gcs.py was incorrectly using recursion to call itself, resulting in infinite loop.

This PR updates the code to download the files locally, which was the intention.

This resulted in a `RecursionError: maximum recursion depth exceeded` because it would start with an input like this:

```
input_videos = ['gs://my-bucket/my-folder/input-videos/intro_clip.mp4']
```

The first loop would take the video string and call itself with the string (not list of strings): `'gs://my-bucket/my-folder/input-videos/intro_clip.mp4'`.

This resulted in `for gcs_uri in gcs_uris:` iterating over the letters and call itself with `g` over and over again. Until hitting the recursion depth error.

