### PR TITLE
Rename output video buckets based on the input file names

### DIFF
--- a/backend/gen_v/storage/__init__.py
+++ b/backend/gen_v/storage/__init__.py
@@ -18,6 +18,7 @@ from gen_v.storage.gcs import retrieve_all_files_from_gcs_folder
 from gen_v.storage.gcs import get_file_name_from_gcs_url
 from gen_v.storage.gcs import upload_file_to_gcs
 from gen_v.storage.gcs import create_gcs_folders_in_subfolder
+from gen_v.storage.gcs import move_blob
 
 __all__ = [
     'download_file_locally',
@@ -26,4 +27,5 @@ __all__ = [
     'get_file_name_from_gcs_url',
     'upload_file_to_gcs',
     'create_gcs_folders_in_subfolder',
+    'move_blob',
 ]

--- a/backend/gen_v/storage/gcs.py
+++ b/backend/gen_v/storage/gcs.py
@@ -205,6 +205,7 @@ def create_gcs_folders_in_subfolder(
       blob.upload_from_string("")  # Create folder if it doesn't exist
       logger.info("Folder created: %s", folder_name)
 
+
 def move_blob(
     source_blob_gcsuri: str,
     destination_folder_name: str,
@@ -217,7 +218,9 @@ def move_blob(
       destination_folder_name: The destination folder for the blob.
   """
   storage_client = storage_client or storage.Client()
-  bucket =storage_client.bucket(get_bucket_name_from_gcs_url(source_blob_gcsuri))
+  bucket = storage_client.bucket(
+      get_bucket_name_from_gcs_url(source_blob_gcsuri)
+  )
   source_blob = bucket.blob(get_path_from_gcs_url(source_blob_gcsuri))
 
   root = "/".join(source_blob_gcsuri.replace("gs://", "").split("/")[1:-2])

--- a/backend/gen_v/storage/gcs.py
+++ b/backend/gen_v/storage/gcs.py
@@ -211,7 +211,7 @@ def move_blob(
     destination_folder_name: str,
     storage_client: storage.Client = None,
 ) -> None:
-  """Moves folders (and their contents) within the same Google Cloud Storage bucket.
+  """Moves folders (and their contents) within the same GCS bucket.
   Args:
       bucket_name: The name of the bucket.
       source_blob_name: The source blob.
@@ -224,7 +224,8 @@ def move_blob(
   source_blob = bucket.blob(get_path_from_gcs_url(source_blob_gcsuri))
 
   root = "/".join(source_blob_gcsuri.replace("gs://", "").split("/")[1:-2])
-  destination = f"{root}/{destination_folder_name}/{get_file_name_from_gcs_url(source_blob_gcsuri)}"
+  file = get_file_name_from_gcs_url(source_blob_gcsuri)
+  destination = f"{root}/{destination_folder_name}/{file}"
   new_blob = bucket.copy_blob(source_blob, bucket, destination)
   source_blob.delete()
 

--- a/backend/gen_v/video/generation.py
+++ b/backend/gen_v/video/generation.py
@@ -234,8 +234,10 @@ def generate_videos_and_download(
 
     storage.download_file_locally(video['gcsUri'], output_video_local_path)
 
+    video_uri = storage.move_blob(video['gcsUri'], file_name)
+
     output_video_files.append({
-        'gcs_uri': video['gcsUri'],
+        'gcs_uri': video_uri,
         'local_file': output_video_local_path,
         'local_file_name': output_video_local_path.rsplit('/', maxsplit=1)[-1],
         'product_title': product['title'],

--- a/backend/gen_v/video/generation.py
+++ b/backend/gen_v/video/generation.py
@@ -27,6 +27,7 @@ import time
 from google import genai
 import google.auth
 from google.auth.transport import requests as google_requests
+from google.cloud import storage as gcp_storage
 from google.genai import types
 import requests
 
@@ -204,6 +205,7 @@ def generate_videos_and_download(
     settings: config.AppSettings,
     output_file_prefix: str,
     product: dict[str, any],
+    storage_client: gcp_storage.Client = None,
 ) -> list[dict[str, any]]:
   """Generates videos, downloads them, and returns their information.
 
@@ -234,7 +236,9 @@ def generate_videos_and_download(
 
     storage.download_file_locally(video['gcsUri'], output_video_local_path)
 
-    video_uri = storage.move_blob(video['gcsUri'], file_name)
+    video_uri = storage.move_blob(
+        video['gcsUri'], file_name, storage_client=storage_client
+    )
 
     output_video_files.append({
         'gcs_uri': video_uri,

--- a/backend/tests/storage/gcs_test.py
+++ b/backend/tests/storage/gcs_test.py
@@ -61,7 +61,11 @@ def fixture_mock_bucket(mock_blob):
   mock_bucket = mock.MagicMock(spec=storage.Bucket)
   mock_bucket.blob.return_value = mock_blob
 
-  def copy_blob(source_blob: storage.Blob, bucket: storage.Bucket, destination: str):  # pylint: disable=unused-argument
+  def copy_blob(
+      source_blob: storage.Blob,  # pylint: disable=unused-argument
+      bucket: storage.Bucket,  # pylint: disable=unused-argument
+      destination: str,
+  ):
     mock_blob.self_link = '/' + destination
     return mock_blob
 
@@ -139,7 +143,7 @@ def test_create_gcs_folders_in_subfolder_with_one_folder(
   assert 'Folder created: new-folder1' in caplog.text
 
 
-def test_move_blob(mock_storage_client, mock_bucket, mock_blob):
+def test_move_blob(mock_storage_client):
 
   source_guri = (
       'gs://bucket_name/existing_folder/existing_subfolder/filename.mp4'

--- a/backend/tests/storage/gcs_test.py
+++ b/backend/tests/storage/gcs_test.py
@@ -52,6 +52,7 @@ def fixture_mock_blob(fs):
   mock_blob.open.return_value.__enter__.return_value.read.return_value = (
       b'This is a test file content.'
   )
+  mock_blob.self_link = ''
   yield mock_blob
 
 
@@ -60,6 +61,11 @@ def fixture_mock_bucket(mock_blob):
   mock_bucket = mock.MagicMock(spec=storage.Bucket)
   mock_bucket.blob.return_value = mock_blob
 
+  def copy_blob(source_blob: storage.Blob, bucket: storage.Bucket, destination: str):  # pylint: disable=unused-argument
+    mock_blob.self_link = '/' + destination
+    return mock_blob
+
+  mock_bucket.copy_blob = copy_blob
   yield mock_bucket
 
 
@@ -133,19 +139,17 @@ def test_create_gcs_folders_in_subfolder_with_one_folder(
   assert 'Folder created: new-folder1' in caplog.text
 
 
-# @pytest.mark.parametrize('exists', [True, False])
-# def test_check_file_exists_failure(mock_exists, mock_storage_client, exists):
-#   mock_exists.return_value = exists
-#   if not exists:
-#     with pytest.raises(FileNotFoundError) as excinfo:
-#       gcs.check_file_exists(
-#           'nonexistent_file.mp4', 'test_bucket', mock_storage_client
-#       )
-#     assert (
-#         str(excinfo.value)
-#         == 'File not found: nonexistent_file.mp4 at bucket test_bucket'
-#     )
-#   else:
-#     assert gcs.check_file_exists(
-#         'existing_file.mp4', 'test_bucket', mock_storage_client
-#     )
+def test_move_blob(mock_storage_client, mock_bucket, mock_blob):
+
+  source_guri = (
+      'gs://bucket_name/existing_folder/existing_subfolder/filename.mp4'
+  )
+  dest_folder = 'destination_folder'
+
+  expected_destination = '/existing_folder/destination_folder/filename.mp4'
+
+  new_link = gcs.move_blob(
+      source_guri, dest_folder, storage_client=mock_storage_client
+  )
+
+  assert new_link == expected_destination


### PR DESCRIPTION
The output folders generate with a random number string - this change renames them based on the input filename, to make it easier to identify the source of the run